### PR TITLE
Add support for TLS with self-signed CA certificate

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -1,5 +1,4 @@
 <?php
-date_default_timezone_set('Europe/Berlin');
 /*
  	phpMQTT
 	A simple php class to connect/publish/subscribe to an MQTT broker


### PR DESCRIPTION
Added support for connecting to an MQTT broker via TLS (typically on port 8883). Specifically, this patch adds the ability to specify a CA certificate file. This is required when using a self-signed CA certificate (presumably since php 5.6, but not sure on that one).

If the server certificate is signed by a CA php recognizes, just using 'tls://broker-address' as address would be enough and this patch is not needed.

I haven't written php code for some time now, so I'm a bit rusty. Comments are welcome :)
