### PR TITLE
Removed parameter "fetch" that prevented receiving large messages

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -324,7 +324,7 @@ class phpMQTT {
 				if($this->debug) echo "Fetching: $value\n";
 				
 				if($value)
-					$string = $this->read($value,"fetch");
+					$string = $this->read($value);
 				
 				if($cmd){
 					switch($cmd){


### PR DESCRIPTION
Thanks for phpMQTT. I use it for an inhouse web service that needs to post and receive messages from mosquitto. Anyway, when receiving large messages, the parameter "fetch" seems to be interfering. I am unsure what it's supposed to do, but removing it fixes the issues.
