### PR TITLE
Add PUBREL for QOS 2 support

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -239,7 +239,7 @@ class phpMQTT {
 		//$buffer .= $this->strwritestring($content,$i);
 
 		if($qos){
-			$id = $this->msgid++;
+			$id = $this->msgid;
 			$buffer .= chr($id >> 8);  $i++;
 		 	$buffer .= chr($id % 256);  $i++;
 		}
@@ -258,6 +258,24 @@ class phpMQTT {
 
 		fwrite($this->socket, $head, strlen($head));
 		fwrite($this->socket, $buffer, $i);
+
+		if($qos == 2)
+		{
+			// Send PUBREL
+			$head = " ";
+			$cmd = 0x62;
+			$head{0} = chr($cmd);
+			$head .= $this->setmsglength(2);
+
+			$id = $this->msgid;
+
+			$head .= chr($id >> 8);
+			$head .= chr($id % 256);
+
+			fwrite($this->socket, $head, strlen($head));
+		}
+
+		$this->msgid++;
 
 	}
 


### PR DESCRIPTION
MQTT client QOS 2 flow requires:

```
QOS 2 - exactly one delivery

Normal Flow

client sends a QoS 2 PUBLISH message and stores in Persistent Outbox
broker replies with PUBREC
client sends PUBREL
broker responds with PUBCOMP
client receives PUBCOMP and deletes message from Persistent Outbox
```
