### PR TITLE
Add SO_KEEPALIVE option to socket connection

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -97,6 +97,7 @@ class phpMQTT {
 
 		stream_set_timeout($this->socket, 5);
 		stream_set_blocking($this->socket, 0);
+		socket_set_option($this->socket, SOL_SOCKET, SO_KEEPALIVE, 1);
 
 		$i = 0;
 		$buffer = "";


### PR DESCRIPTION
Prevents socket from being closed by the MQTT server after 60 seconds by setting the SO_KEEPALIVE flag on the connection.