### PR TITLE
add encryption for connection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.4"
+        "php": ">=7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -105,7 +105,8 @@ class phpMQTT {
     /**
      * Only required if the DNS of a MQTT server returns IPv4 and IPv6 but the server offers only one ip version
      * Should be NEVER the case in a productive environment!!!
-     * @param int $ip_version valid values: IPv4: 4, IPv6: 6
+     * @param bool $enabled
+     * @param int  $ip_version valid values: IPv4: 4, IPv6: 6
      * @throws \InvalidArgumentException
      */
     public function set_force_ip_version(bool $enabled, int $ip_version)


### PR DESCRIPTION
Thanks for the library!
I needed some more utility and added some functions for encrypted connections.

### Additions
add encryption for connection
add timeout config
add IPv4/6 force

### Change
fix "tls" instead of "ssl" for ca connections, "tls" only allows tls1.0 but "ssl" uses newer versions

### Backwards compatibility
Had to increase to php7, older php versions too mature for useful crypto stuff.