### PR TITLE
Resolve issue with ping timeout #42

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -224,6 +224,7 @@ class phpMQTT {
 			$head = chr(0xc0);		
 			$head .= chr(0x00);
 			fwrite($this->socket, $head, 2);
+			$this->timesinceping = time();
 			if($this->debug) echo "ping sent\n";
 	}
 
@@ -345,8 +346,6 @@ class phpMQTT {
 							$this->message($string);
 						break;
 					}
-
-					$this->timesinceping = time();
 				}
 			}
 


### PR DESCRIPTION
As commented in bluerhinos#42:
It seems that Mosquitto broker expecting to receive ping within timeout period regardless of messages sent to client within this period of time (not tested this behavior on other brokers). In "proc" method, "timesinceping" updated when EVERY type of message being received, not only ping response and this causes to delay next ping to broker. This, in turn, cause to timeout on broker side and it forcing to close connection.
Additionally, resolves the problem when ping is sent twice every time.