### PR TITLE
Single character getting compatible with php 7.4

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -239,14 +239,14 @@ class phpMQTT
 
         $string = $this->read(4);
 
-        if (ord($string{0}) >> 4 === 2 && $string{3} === chr(0)) {
+        if (ord($string[0]) >> 4 === 2 && $string[3] === chr(0)) {
             $this->_debugMessage('Connected to Broker');
         } else {
             $this->_errorMessage(
                 sprintf(
                     "Connection failed! (Error: 0x%02x 0x%02x)\n",
-                    ord($string{0}),
-                    ord($string{3})
+                    ord($string[0]),
+                    ord($string[3])
                 )
             );
             return false;
@@ -365,8 +365,8 @@ class phpMQTT
     public function disconnect(): void
     {
         $head = ' ';
-        $head{0} = chr(0xe0);
-        $head{1} = chr(0x00);
+        $head[0] = chr(0xe0);
+        $head[1] = chr(0x00);
         fwrite($this->socket, $head, 2);
     }
 
@@ -414,7 +414,7 @@ class phpMQTT
             ++$cmd;
         }
 
-        $head{0} = chr($cmd);
+        $head[0] = chr($cmd);
         $head .= $this->setmsglength($i);
 
         fwrite($this->socket, $head, strlen($head));
@@ -449,7 +449,7 @@ class phpMQTT
      */
     public function message($msg)
     {
-        $tlen = (ord($msg{0}) << 8) + ord($msg{1});
+        $tlen = (ord($msg[0]) << 8) + ord($msg[1]);
         $topic = substr($msg, 2, $tlen);
         $msg = substr($msg, ($tlen + 2));
         $found = false;
@@ -583,7 +583,7 @@ class phpMQTT
         $multiplier = 1;
         $value = 0;
         do {
-            $digit = ord($msg{$i});
+            $digit = ord($msg[$i]);
             $value += ($digit & 127) * $multiplier;
             $multiplier *= 128;
             $i++;
@@ -639,9 +639,9 @@ class phpMQTT
     {
         $strlen = strlen($string);
         for ($j = 0; $j < $strlen; $j++) {
-            $num = ord($string{$j});
+            $num = ord($string[$j]);
             if ($num > 31) {
-                $chr = $string{$j};
+                $chr = $string[$j];
             } else {
                 $chr = ' ';
             }


### PR DESCRIPTION
Since PHP 7.4. curly braces method to get individual characters inside a string has been deprecated