### PR TITLE
fix QoS in SUBSCRIBE

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -333,8 +333,6 @@ class phpMQTT
         }
 
         $cmd = 0x82;
-        //$qos
-        $cmd += ($qos << 1);
 
         $head = chr($cmd);
         $head .= $this->setmsglength($i);


### PR DESCRIPTION
According to [MQTT spec](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718063) the fixed header of SUBSCRIBE should be 0x82; the QoS doesn't go there. The QoS is just is part of the payload.