### PR TITLE
Small fix in message debug log

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -474,6 +474,8 @@ class phpMQTT
                 ) . '$/',
                 $topic
             )) {
+                $found = true;
+
                 if ($top['function'] === '__direct_return_message__') {
                     return $msg;
                 }


### PR DESCRIPTION
When a message was received with a matching topic, 'msg received but no match in subscriptions' was erroneously logged.