### PR TITLE
Update phpMQTT.php

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -193,10 +193,11 @@ class phpMQTT
 
         if ($this->username !== null) {
             $var += 128;
+		
+            if ($this->password !== null) {
+                $var += 64;
+            }    //Add password to header, only if username is not null, per http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.pdf, line 525
         }    //Add username to header
-        if ($this->password !== null) {
-            $var += 64;
-        }    //Add password to header
 
         $buffer .= chr($var);
         $i++;


### PR DESCRIPTION
The password flag should be set only if there is a username, per http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.pdf, line 525:

"if the User Name Flag is set to 0, the Password Flag MUST be set to 0 [MQTT-3.1.2-22]. "