### PR TITLE
Mitigate endless loop broken pipe error

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -431,7 +431,13 @@ class phpMQTT
     protected function _fwrite($buffer)
     {
         $buffer_length = strlen($buffer);
+        $overflowcounter = 0;
         for ($written = 0; $written < $buffer_length; $written += $fwrite) {
+            $overflowcounter++ ;
+            if ($overflowcounter > ($buffer_length * 2)){
+              print "ERROR sending data in phpMQTT.php" . PHP_EOL;
+                return false;
+            }
             $fwrite = fwrite($this->socket, substr($buffer, $written));
             if ($fwrite === false) {
                 return false;


### PR DESCRIPTION
The code can end up in an endless loop if a broken pipe is experienced in the _fwrite function. This is a rudimentary mitigation by counting the iterations and comparing it to the buffer_length. If the iterations are double the buffer_length, there is a high risk that it is stuck in an endless loop. 

```
PHP Notice:  fwrite(): send of 2013 bytes failed with errno=32 Broken pipe in /phpMQTT.php on line 435
```